### PR TITLE
cmake can find fftw and cfitsio now from ENV

### DIFF
--- a/cmake/FindCFITSIO.cmake
+++ b/cmake/FindCFITSIO.cmake
@@ -16,18 +16,13 @@
 
 # JM: Packages from different distributions have different suffixes
 find_path(CFITSIO_INCLUDE_DIR fitsio.h
-	PATH_SUFFIXES libcfitsio3 libcfitsio0 cfitsio
-	PATHS
-	$ENV{CFITSIO}
-	${_obIncDir}
-	${GNUWIN32_DIR}/include
+	PATH_SUFFIXES libcfitsio3 libcfitsio0 cfitsio include inc
+	PATHS $ENV{CFITSIO} $ENV{CFITSIO_BASE} ${_obIncDir} ${GNUWIN32_DIR}
 	)
 
 find_library(CFITSIO_LIBRARIES NAMES cfitsio
-	PATHS
-	$ENV{CFITSIO}
-	${_obLinkDir}
-	${GNUWIN32_DIR}/lib
+	PATH_SUFFIXES lib
+	PATHS $ENV{CFITSIO} ${CFITSIO_BASE} ${_obLinkDir} ${GNUWIN32_DIR}
 	)
 
 if(CFITSIO_INCLUDE_DIR AND CFITSIO_LIBRARIES)

--- a/cmake/FindFFTW3F.cmake
+++ b/cmake/FindFFTW3F.cmake
@@ -3,8 +3,18 @@
 # FFTW3F_INCLUDE_DIR = fftw3.h
 # FFTW3F_LIBRARIES = libfftw3f.a .so
 
-find_path(FFTW3F_INCLUDE_DIR fftw3.h)
-find_library(FFTW3F_LIBRARIES fftw3f)
+
+find_path(FFTW3F_INCLUDE_DIR fftw3.h
+        PATH_SUFFIXES include inc
+        PATHS $ENV{FFTW_BASE} $ENV{FFTW}
+        )
+message(STATUS "FFTW3F header => ${FFTW3F_INCLUDE_DIR}")
+
+find_library(FFTW3F_LIBRARIES fftw3f
+        PATH_SUFFIXES lib
+        PATHS  $ENV{FFTW_BASE} $ENV{FFTW}
+        )
+message(STATUS "FFTW3F libs => ${FFTW3F_LIBRARIES}")
 
 set(FFTW3F_FOUND FALSE)
 if(FFTW3F_INCLUDE_DIR AND FFTW3F_LIBRARIES)


### PR DESCRIPTION
Motivation: https://github.com/cosmicrays/hermes/issues/23

A small patch to allow the cmake build to find 
fftw at FFTW_BASE or FFTW 
and
cfitsio at CFITSIO_BASE or CFITSIO
this will allow users to install these requiernments in custom location which is very handy for multi user systems (e.g. HPC)

The patch was tested with the following system:
uname -a
Linux 4.15.0-171-generic #180-Ubuntu
gcc 9.1
cmake 3.18.4